### PR TITLE
Improve HasMetaData and expand trait behavior tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - main
+      - work
+  pull_request:
+
+jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+
+      - name: Validate composer.json
+        run: composer validate --no-check-publish
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Run tests
+        run: composer test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mimisk/laravel-toolbox
 
-Minimal Laravel 12 package scaffold for reusable toolbox utilities.
+Reusable Eloquent traits for Laravel 12 projects.
 
 ## Requirements
 
@@ -13,27 +13,76 @@ Minimal Laravel 12 package scaffold for reusable toolbox utilities.
 composer require mimisk/laravel-toolbox
 ```
 
-The package service provider is auto-discovered by Laravel.
+`ToolboxServiceProvider` is auto-discovered by Laravel.
+
+If you want to publish package config:
+
+```bash
+php artisan vendor:publish --tag=toolbox-config
+```
+
+## Usage
+
+### 1) Add traits to your model
+
+```php
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Mimisk\LaravelToolbox\Traits\HasActiveFlag;
+use Mimisk\LaravelToolbox\Traits\HasArchivedState;
+use Mimisk\LaravelToolbox\Traits\HasMetaData;
+use Mimisk\LaravelToolbox\Traits\HasPublishedState;
+use Mimisk\LaravelToolbox\Traits\HasSlug;
+use Mimisk\LaravelToolbox\Traits\HasSortOrder;
+use Mimisk\LaravelToolbox\Traits\HasUlid;
+use Mimisk\LaravelToolbox\Traits\HasUuid;
+
+class Post extends Model
+{
+    use HasActiveFlag;
+    use HasArchivedState;
+    use HasMetaData;
+    use HasPublishedState;
+    use HasSlug;
+    use HasSortOrder;
+    use HasUlid;
+    use HasUuid;
+}
+```
+
+### 2) Ensure migration columns exist
+
+```php
+$table->uuid('uuid')->nullable();
+$table->string('ulid')->nullable();
+$table->string('slug')->nullable();
+$table->boolean('is_active')->default(true);
+$table->timestamp('published_at')->nullable();
+$table->timestamp('archived_at')->nullable();
+$table->integer('sort_order')->nullable();
+$table->json('metadata')->nullable();
+```
 
 ## Included Traits
 
-### `HasUuid`
-Automatically sets a UUID on model creation (default column: `uuid`).
+- `HasUuid`: auto-generates a UUID on creating (`uuid`).
+- `HasUlid`: auto-generates a ULID on creating (`ulid`).
+- `HasSlug`: auto-generates a slug from `title` (`slug`).
+- `HasActiveFlag`: active/inactive scopes and activate/deactivate helpers (`is_active`).
+- `HasPublishedState`: published/unpublished scopes and publish helpers (`published_at`).
+- `HasArchivedState`: archived/unarchived scopes and archive helpers (`archived_at`).
+- `HasSortOrder`: auto-assigns incremental order and adds `ordered()` scope (`sort_order`).
+- `HasMetaData`: metadata `get/set/has/forget` helpers (`metadata`).
 
-### `HasSlug`
-Automatically generates a slug on model creation from a source attribute (default source: `title`, target column: `slug`).
-
-### `HasActiveFlag`
-Adds active/inactive scopes and helpers for boolean flags (default column: `is_active`).
-
-### `HasPublishedState`
-Adds published/unpublished scopes and helpers using a datetime field (default column: `published_at`).
-
-### `HasMetaData`
-Adds helpers for structured metadata access via an array-cast attribute (default column: `metadata`).
+Most traits support custom column methods (e.g. `getSlugColumn()`, `getUuidColumn()`, etc.) if you want to override defaults.
 
 ## Testing
 
 ```bash
 composer test
 ```
+
+CI runs on every push/PR through GitHub Actions (`.github/workflows/tests.yml`).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# mimisk/laravel-toolbox
+
+Minimal Laravel 12 package scaffold for reusable toolbox utilities.
+
+## Requirements
+
+- PHP 8.4+
+- Laravel 12+
+
+## Installation
+
+```bash
+composer require mimisk/laravel-toolbox
+```
+
+The package service provider is auto-discovered by Laravel.
+
+## Included Traits
+
+### `HasUuid`
+Automatically sets a UUID on model creation (default column: `uuid`).
+
+### `HasSlug`
+Automatically generates a slug on model creation from a source attribute (default source: `title`, target column: `slug`).
+
+### `HasActiveFlag`
+Adds active/inactive scopes and helpers for boolean flags (default column: `is_active`).
+
+### `HasPublishedState`
+Adds published/unpublished scopes and helpers using a datetime field (default column: `published_at`).
+
+### `HasMetaData`
+Adds helpers for structured metadata access via an array-cast attribute (default column: `metadata`).
+
+## Testing
+
+```bash
+composer test
+```

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,36 @@
+{
+    "name": "mimisk/laravel-toolbox",
+    "description": "A minimal toolbox package for Laravel applications.",
+    "type": "library",
+    "license": "MIT",
+    "require": {
+        "php": "^8.4",
+        "illuminate/support": "^12.0"
+    },
+    "require-dev": {
+        "orchestra/testbench": "^10.0",
+        "phpunit/phpunit": "^11.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Mimisk\\LaravelToolbox\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Mimisk\\LaravelToolbox\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Mimisk\\LaravelToolbox\\ToolboxServiceProvider"
+            ]
+        }
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true,
+    "scripts": {
+        "test": "phpunit"
+    }
+}

--- a/config/toolbox.php
+++ b/config/toolbox.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'enabled' => true,
+];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Laravel Toolbox Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/ToolboxServiceProvider.php
+++ b/src/ToolboxServiceProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mimisk\LaravelToolbox;
+
+use Illuminate\Support\ServiceProvider;
+
+class ToolboxServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__.'/../config/toolbox.php', 'toolbox');
+    }
+
+    public function boot(): void
+    {
+        $this->publishes([
+            __DIR__.'/../config/toolbox.php' => config_path('toolbox.php'),
+        ], 'toolbox-config');
+    }
+}

--- a/src/Traits/HasActiveFlag.php
+++ b/src/Traits/HasActiveFlag.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mimisk\LaravelToolbox\Traits;
+
+use Illuminate\Database\Eloquent\Builder;
+
+trait HasActiveFlag
+{
+    public static function bootHasActiveFlag(): void
+    {
+        static::creating(function ($model): void {
+            $column = method_exists($model, 'getActiveFlagColumn') ? $model->getActiveFlagColumn() : 'is_active';
+
+            if ($model->{$column} === null) {
+                $model->{$column} = true;
+            }
+        });
+    }
+
+    public function scopeActive(Builder $query): Builder
+    {
+        $column = method_exists($this, 'getActiveFlagColumn') ? $this->getActiveFlagColumn() : 'is_active';
+
+        return $query->where($column, true);
+    }
+
+    public function scopeInactive(Builder $query): Builder
+    {
+        $column = method_exists($this, 'getActiveFlagColumn') ? $this->getActiveFlagColumn() : 'is_active';
+
+        return $query->where($column, false);
+    }
+
+    public function activate(): bool
+    {
+        $column = method_exists($this, 'getActiveFlagColumn') ? $this->getActiveFlagColumn() : 'is_active';
+        $this->{$column} = true;
+
+        return $this->save();
+    }
+
+    public function deactivate(): bool
+    {
+        $column = method_exists($this, 'getActiveFlagColumn') ? $this->getActiveFlagColumn() : 'is_active';
+        $this->{$column} = false;
+
+        return $this->save();
+    }
+}

--- a/src/Traits/HasArchivedState.php
+++ b/src/Traits/HasArchivedState.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mimisk\LaravelToolbox\Traits;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+
+trait HasArchivedState
+{
+    public function scopeArchived(Builder $query): Builder
+    {
+        return $query->whereNotNull($this->getArchivedAtColumnName());
+    }
+
+    public function scopeUnarchived(Builder $query): Builder
+    {
+        return $query->whereNull($this->getArchivedAtColumnName());
+    }
+
+    public function markAsArchived(?Carbon $archivedAt = null): bool
+    {
+        $this->{$this->getArchivedAtColumnName()} = $archivedAt ?? Carbon::now();
+
+        return $this->save();
+    }
+
+    public function markAsUnarchived(): bool
+    {
+        $this->{$this->getArchivedAtColumnName()} = null;
+
+        return $this->save();
+    }
+
+    public function isArchived(): bool
+    {
+        return $this->{$this->getArchivedAtColumnName()} !== null;
+    }
+
+    protected function getArchivedAtColumnName(): string
+    {
+        return method_exists($this, 'getArchivedAtColumn') ? $this->getArchivedAtColumn() : 'archived_at';
+    }
+}

--- a/src/Traits/HasMetaData.php
+++ b/src/Traits/HasMetaData.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mimisk\LaravelToolbox\Traits;
+
+use Illuminate\Support\Arr;
+
+trait HasMetaData
+{
+    public function initializeHasMetaData(): void
+    {
+        $column = $this->getMetaDataColumnName();
+
+        if (method_exists($this, 'mergeCasts')) {
+            $this->mergeCasts([$column => 'array']);
+
+            return;
+        }
+
+        $this->casts[$column] = 'array';
+    }
+
+    public function getMeta(string $key, mixed $default = null): mixed
+    {
+        return data_get($this->getMetaDataPayload(), $key, $default);
+    }
+
+    public function setMeta(string $key, mixed $value): self
+    {
+        $metadata = $this->getMetaDataPayload();
+        data_set($metadata, $key, $value);
+
+        $this->{$this->getMetaDataColumnName()} = $metadata;
+
+        return $this;
+    }
+
+    public function hasMeta(string $key): bool
+    {
+        return Arr::has($this->getMetaDataPayload(), $key);
+    }
+
+    public function forgetMeta(string $key): self
+    {
+        $metadata = $this->getMetaDataPayload();
+        data_forget($metadata, $key);
+
+        $this->{$this->getMetaDataColumnName()} = $metadata;
+
+        return $this;
+    }
+
+    protected function getMetaDataPayload(): array
+    {
+        $payload = $this->{$this->getMetaDataColumnName()} ?? [];
+
+        return is_array($payload) ? $payload : [];
+    }
+
+    protected function getMetaDataColumnName(): string
+    {
+        return method_exists($this, 'getMetaDataColumn') ? $this->getMetaDataColumn() : 'metadata';
+    }
+}

--- a/src/Traits/HasPublishedState.php
+++ b/src/Traits/HasPublishedState.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mimisk\LaravelToolbox\Traits;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+
+trait HasPublishedState
+{
+    public function scopePublished(Builder $query): Builder
+    {
+        $column = method_exists($this, 'getPublishedAtColumn') ? $this->getPublishedAtColumn() : 'published_at';
+
+        return $query->whereNotNull($column);
+    }
+
+    public function scopeUnpublished(Builder $query): Builder
+    {
+        $column = method_exists($this, 'getPublishedAtColumn') ? $this->getPublishedAtColumn() : 'published_at';
+
+        return $query->whereNull($column);
+    }
+
+    public function markAsPublished(?Carbon $publishedAt = null): bool
+    {
+        $column = method_exists($this, 'getPublishedAtColumn') ? $this->getPublishedAtColumn() : 'published_at';
+        $this->{$column} = $publishedAt ?? Carbon::now();
+
+        return $this->save();
+    }
+
+    public function markAsUnpublished(): bool
+    {
+        $column = method_exists($this, 'getPublishedAtColumn') ? $this->getPublishedAtColumn() : 'published_at';
+        $this->{$column} = null;
+
+        return $this->save();
+    }
+
+    public function isPublished(): bool
+    {
+        $column = method_exists($this, 'getPublishedAtColumn') ? $this->getPublishedAtColumn() : 'published_at';
+
+        return $this->{$column} !== null;
+    }
+}

--- a/src/Traits/HasSlug.php
+++ b/src/Traits/HasSlug.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mimisk\LaravelToolbox\Traits;
+
+use Illuminate\Support\Str;
+
+trait HasSlug
+{
+    public static function bootHasSlug(): void
+    {
+        static::creating(function ($model): void {
+            $model->generateSlug();
+        });
+    }
+
+    public function generateSlug(): void
+    {
+        $slugColumn = method_exists($this, 'getSlugColumn') ? $this->getSlugColumn() : 'slug';
+
+        if (! empty($this->{$slugColumn})) {
+            return;
+        }
+
+        $sourceColumn = method_exists($this, 'getSlugSourceColumn') ? $this->getSlugSourceColumn() : 'title';
+        $separator = method_exists($this, 'getSlugSeparator') ? $this->getSlugSeparator() : '-';
+
+        if (! empty($this->{$sourceColumn})) {
+            $this->{$slugColumn} = Str::slug((string) $this->{$sourceColumn}, $separator);
+        }
+    }
+}

--- a/src/Traits/HasSortOrder.php
+++ b/src/Traits/HasSortOrder.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mimisk\LaravelToolbox\Traits;
+
+use Illuminate\Database\Eloquent\Builder;
+
+trait HasSortOrder
+{
+    public static function bootHasSortOrder(): void
+    {
+        static::creating(function ($model): void {
+            $column = method_exists($model, 'getSortOrderColumn') ? $model->getSortOrderColumn() : 'sort_order';
+
+            if ($model->{$column} !== null) {
+                return;
+            }
+
+            $model->{$column} = (int) static::query()->max($column) + 1;
+        });
+    }
+
+    public function scopeOrdered(Builder $query, string $direction = 'asc'): Builder
+    {
+        $column = method_exists($this, 'getSortOrderColumn') ? $this->getSortOrderColumn() : 'sort_order';
+
+        return $query->orderBy($column, $direction);
+    }
+}

--- a/src/Traits/HasUlid.php
+++ b/src/Traits/HasUlid.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mimisk\LaravelToolbox\Traits;
+
+use Illuminate\Support\Str;
+
+trait HasUlid
+{
+    public static function bootHasUlid(): void
+    {
+        static::creating(function ($model): void {
+            $column = method_exists($model, 'getUlidColumn') ? $model->getUlidColumn() : 'ulid';
+
+            if (! $model->{$column}) {
+                $model->{$column} = (string) Str::ulid();
+            }
+        });
+    }
+}

--- a/src/Traits/HasUuid.php
+++ b/src/Traits/HasUuid.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mimisk\LaravelToolbox\Traits;
+
+use Illuminate\Support\Str;
+
+trait HasUuid
+{
+    public static function bootHasUuid(): void
+    {
+        static::creating(function ($model): void {
+            $column = method_exists($model, 'getUuidColumn') ? $model->getUuidColumn() : 'uuid';
+
+            if (! $model->{$column}) {
+                $model->{$column} = (string) Str::uuid();
+            }
+        });
+    }
+}

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mimisk\LaravelToolbox\Tests;
+
+use Mimisk\LaravelToolbox\ToolboxServiceProvider;
+
+class ServiceProviderTest extends TestCase
+{
+    public function test_service_provider_is_loaded(): void
+    {
+        $this->assertTrue($this->app->providerIsLoaded(ToolboxServiceProvider::class));
+        $this->assertTrue($this->app['config']->get('toolbox.enabled'));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mimisk\LaravelToolbox\Tests;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Mimisk\LaravelToolbox\ToolboxServiceProvider;
+use Orchestra\Testbench\TestCase as Orchestra;
+
+abstract class TestCase extends Orchestra
+{
+    protected function getEnvironmentSetUp($app): void
+    {
+        $app['config']->set('database.default', 'testing');
+        $app['config']->set('database.connections.testing', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            ToolboxServiceProvider::class,
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('test_posts', function (Blueprint $table): void {
+            $table->id();
+            $table->string('title')->nullable();
+            $table->string('slug')->nullable();
+            $table->uuid('uuid')->nullable();
+            $table->boolean('is_active')->nullable();
+            $table->timestamp('published_at')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('test_posts');
+
+        parent::tearDown();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -37,8 +37,11 @@ abstract class TestCase extends Orchestra
             $table->string('title')->nullable();
             $table->string('slug')->nullable();
             $table->uuid('uuid')->nullable();
+            $table->string('ulid')->nullable();
             $table->boolean('is_active')->nullable();
             $table->timestamp('published_at')->nullable();
+            $table->timestamp('archived_at')->nullable();
+            $table->integer('sort_order')->nullable();
             $table->json('metadata')->nullable();
             $table->timestamps();
         });

--- a/tests/TraitsTest.php
+++ b/tests/TraitsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mimisk\LaravelToolbox\Tests;
+
+use Illuminate\Database\Eloquent\Model;
+use Mimisk\LaravelToolbox\Traits\HasActiveFlag;
+use Mimisk\LaravelToolbox\Traits\HasMetaData;
+use Mimisk\LaravelToolbox\Traits\HasPublishedState;
+use Mimisk\LaravelToolbox\Traits\HasSlug;
+use Mimisk\LaravelToolbox\Traits\HasUuid;
+
+class TraitsTest extends TestCase
+{
+    public function test_model_traits_apply_expected_defaults_and_helpers(): void
+    {
+        $post = TestPost::query()->create(['title' => 'My First Post']);
+
+        $this->assertNotEmpty($post->uuid);
+        $this->assertSame('my-first-post', $post->slug);
+        $this->assertTrue($post->is_active);
+
+        $this->assertFalse($post->isPublished());
+        $post->markAsPublished();
+        $this->assertTrue($post->fresh()->isPublished());
+
+        $post->setMeta('seo.description', 'hello');
+        $this->assertTrue($post->hasMeta('seo.description'));
+        $this->assertSame('hello', $post->getMeta('seo.description'));
+
+        $post->forgetMeta('seo.description');
+        $this->assertFalse($post->hasMeta('seo.description'));
+    }
+
+    public function test_active_and_published_scopes(): void
+    {
+        $active = TestPost::query()->create(['title' => 'Active']);
+        $inactive = TestPost::query()->create(['title' => 'Inactive', 'is_active' => false]);
+        $published = TestPost::query()->create(['title' => 'Published', 'published_at' => now()]);
+
+        $this->assertSame([$active->id, $published->id], TestPost::query()->active()->pluck('id')->all());
+        $this->assertSame([$inactive->id], TestPost::query()->inactive()->pluck('id')->all());
+        $this->assertSame([$published->id], TestPost::query()->published()->pluck('id')->all());
+    }
+}
+
+class TestPost extends Model
+{
+    use HasActiveFlag;
+    use HasMetaData;
+    use HasPublishedState;
+    use HasSlug;
+    use HasUuid;
+
+    protected $table = 'test_posts';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'published_at' => 'datetime',
+    ];
+}

--- a/tests/TraitsTest.php
+++ b/tests/TraitsTest.php
@@ -6,9 +6,12 @@ namespace Mimisk\LaravelToolbox\Tests;
 
 use Illuminate\Database\Eloquent\Model;
 use Mimisk\LaravelToolbox\Traits\HasActiveFlag;
+use Mimisk\LaravelToolbox\Traits\HasArchivedState;
 use Mimisk\LaravelToolbox\Traits\HasMetaData;
 use Mimisk\LaravelToolbox\Traits\HasPublishedState;
 use Mimisk\LaravelToolbox\Traits\HasSlug;
+use Mimisk\LaravelToolbox\Traits\HasSortOrder;
+use Mimisk\LaravelToolbox\Traits\HasUlid;
 use Mimisk\LaravelToolbox\Traits\HasUuid;
 
 class TraitsTest extends TestCase
@@ -18,12 +21,18 @@ class TraitsTest extends TestCase
         $post = TestPost::query()->create(['title' => 'My First Post']);
 
         $this->assertNotEmpty($post->uuid);
+        $this->assertNotEmpty($post->ulid);
         $this->assertSame('my-first-post', $post->slug);
         $this->assertTrue($post->is_active);
+        $this->assertSame(1, $post->sort_order);
 
         $this->assertFalse($post->isPublished());
         $post->markAsPublished();
         $this->assertTrue($post->fresh()->isPublished());
+
+        $this->assertFalse($post->isArchived());
+        $post->markAsArchived();
+        $this->assertTrue($post->fresh()->isArchived());
 
         $post->setMeta('seo.description', 'hello');
         $this->assertTrue($post->hasMeta('seo.description'));
@@ -33,24 +42,36 @@ class TraitsTest extends TestCase
         $this->assertFalse($post->hasMeta('seo.description'));
     }
 
-    public function test_active_and_published_scopes(): void
+    public function test_active_published_archived_and_ordered_scopes(): void
     {
         $active = TestPost::query()->create(['title' => 'Active']);
         $inactive = TestPost::query()->create(['title' => 'Inactive', 'is_active' => false]);
         $published = TestPost::query()->create(['title' => 'Published', 'published_at' => now()]);
+        $archived = TestPost::query()->create(['title' => 'Archived', 'archived_at' => now()]);
 
-        $this->assertSame([$active->id, $published->id], TestPost::query()->active()->pluck('id')->all());
+        $this->assertSame([$active->id, $published->id, $archived->id], TestPost::query()->active()->pluck('id')->all());
         $this->assertSame([$inactive->id], TestPost::query()->inactive()->pluck('id')->all());
         $this->assertSame([$published->id], TestPost::query()->published()->pluck('id')->all());
+        $this->assertSame([$active->id, $inactive->id, $published->id], TestPost::query()->unarchived()->pluck('id')->all());
+        $this->assertSame([$archived->id], TestPost::query()->archived()->pluck('id')->all());
+        $this->assertSame([
+            $active->id,
+            $inactive->id,
+            $published->id,
+            $archived->id,
+        ], TestPost::query()->ordered()->pluck('id')->all());
     }
 }
 
 class TestPost extends Model
 {
     use HasActiveFlag;
+    use HasArchivedState;
     use HasMetaData;
     use HasPublishedState;
     use HasSlug;
+    use HasSortOrder;
+    use HasUlid;
     use HasUuid;
 
     protected $table = 'test_posts';
@@ -59,5 +80,6 @@ class TestPost extends Model
 
     protected $casts = [
         'published_at' => 'datetime',
+        'archived_at' => 'datetime',
     ];
 }


### PR DESCRIPTION
### Motivation
- Increase confidence in the package traits by exercising real Eloquent behavior instead of only checking trait existence. 
- Make `HasMetaData` safer and more reusable for nested keys and cast initialization.

### Description
- Update `HasMetaData` to add `getMetaDataColumnName()` and `getMetaDataPayload()` helpers, use `Arr::has()` for nested key checks, and prefer `mergeCasts()` when available with a fallback to direct cast assignment. 
- Expand the Testbench base `tests/TestCase.php` to configure an in-memory SQLite connection and create/drop a `test_posts` schema for behavior tests. 
- Replace the simple trait loadability test with `tests/TraitsTest.php` behavior-focused tests that validate UUID/slug/default active state, publish/unpublish helpers, metadata `get/set/has/forget`, and active/published scopes. 
- Keep service provider and package scaffolding intact (config merge/publish support and testbench provider registration).

### Testing
- Ran `composer validate --no-check-publish` which succeeded. 
- Ran `find src tests config -name '*.php' -print0 | xargs -0 -n1 php -l` which reported no syntax errors. 
- `composer install` failed due to environment network restrictions contacting Packagist (CONNECT tunnel failed, response 403). 
- `composer test` could not run because dependencies (including `phpunit`) were not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e1df5334832183e33d7e34e6b333)